### PR TITLE
Added 'test' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"onCommand:npm-script.install",
 		"onCommand:npm-script.run",
 		"onCommand:npm-script.showOutput",
-		"onCommand:npm-script.rerun-last-script"
+		"onCommand:npm-script.rerun-last-script",
+		"onCommand:npm-script.test"
 	],
 	"main": "./out/src/main",
 	"contributes": {
@@ -46,6 +47,11 @@
 			{
 				"command": "npm-script.rerun-last-script",
 				"title": "Rerun last script",
+				"category": "npm"
+			},
+			{
+				"command": "npm-script.test",
+				"title": "test",
 				"category": "npm"
 			}
 		],

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ function registerCommands(context: ExtensionContext) {
 	let c2 = commands.registerCommand('npm-script.install', runNpmInstall);
 	let c3 = commands.registerCommand('npm-script.run', runNpmScript);
 	let c4 = commands.registerCommand('npm-script.rerun-last-script', rerunLastScript);
-	context.subscriptions.push(c1, c2, c3, c4);
+	let c5 = commands.registerCommand('npm-script.test', runNpmTest);
+	context.subscriptions.push(c1, c2, c3, c4, c5);
 }
 
 function runNpmInstall() {
@@ -33,6 +34,10 @@ function runNpmInstall() {
 	for (let dir of dirs) {
 		runNpmCommand(['install'], dir);
 	}
+}
+
+function runNpmTest() {
+	runNpmCommand(['test']);
 }
 
 function showNpmOutput(): void {


### PR DESCRIPTION
This change puts "npm test" in the commands for the extension. It was accessible through "run-script", but this just skips the second menu.