### PR TITLE
Added option to ignore root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The commands defined by this extensions are in the `npm` category.
 - With the setting `npm.runInTerminal` you configure whether the command is run
 in a terminal window or whether the output form the command is shown in the `Output` window.
 - If you have a subdirectory in your project with its own `package.json` file you can add it to the setting `npm.includeDirectories`.
+- If your root directory does not happen to contain `package.json` you can set `npm.useRootDirectory` to false to ignore the root directory.
 
 ##### Example
 ```javascript

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
 					"type": "array",
 					"default": [],
 					"description": "Look for 'package.json' files in these directories"
+				},
+				"npm.useRootDirectory": {
+					"type": "boolean",
+					"default": true,
+					"description": "Look for 'package.json' in the root directory of the workspace"
 				}
 			}
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,7 +148,10 @@ function useTerminal() {
 
 function getIncludedDirectories() {
 	let dirs = [];
-	dirs.push(workspace.rootPath);
+
+	if (workspace.getConfiguration('npm')['useRootDirectory'] !== false) {
+		dirs.push(workspace.rootPath);
+	}
 
 	if (workspace.getConfiguration('npm')['includeDirectories'].length > 0) {
 		for (let dir of workspace.getConfiguration('npm')['includeDirectories']) {


### PR DESCRIPTION
Even if additional directories are given the root directory is always
checked, which can prevent the additional directories from being checked
if their is no `package.json` in the root directory. This adds an option
to avoid this issue.