### PR TITLE
Added command to kill running process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This extension supports running scripts defined in the `package.json` file.
 - Run a script (`npm run-script`) defined in the `package.json` by picking a script
 defined in the `scripts` section of the `package.json`.
 - Rerun the last npm script you have executed using this extension.
+- Terminate a running script
 
 ## Using
 
@@ -38,6 +39,7 @@ The extension defines a chording keyboard shortcut for the `R` key. As a consequ
 
 ## Release Notes
 
+- 0.0.14 added command to terminate a running script
 - 0.0.13 save workspace before running scripts, added command to run `npm run build`
 - 0.0.12 added support for `npm.useRootDirectory`
 - 0.0.11 added command to run `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,116 +1,128 @@
 {
-	"name": "vscode-npm-script",
-	"description": "Run npm scripts from the Command Palette",
-	"displayName": "npm Script Runner",
-	"version": "0.0.12",
-	"publisher": "eg2",
-	"icon": "npm_icon.png",
-	"engines": {
-		"vscode": "^0.10.6"
-	},
-	"homepage": "https://github.com/Microsoft/vscode-npm-scripts/blob/master/README.md",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-npm-scripts.git"
-	},
-	"bugs": {
-		"url": "https://github.com/Microsoft/vscode-npm-scripts/issues"
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-		"onCommand:npm-script.install",
-		"onCommand:npm-script.run",
-		"onCommand:npm-script.showOutput",
-		"onCommand:npm-script.rerun-last-script",
-		"onCommand:npm-script.test"
-	],
-	"main": "./out/src/main",
-	"contributes": {
-		"commands": [
-			{
-				"command": "npm-script.install",
-				"title": "install",
-				"category": "npm"
-			},
-			{
-				"command": "npm-script.run",
-				"title": "Run script",
-				"category": "npm"
-			},
-			{
-				"command": "npm-script.showOutput",
-				"title": "Show output",
-				"category": "npm"
-			},
-			{
-				"command": "npm-script.rerun-last-script",
-				"title": "Rerun last script",
-				"category": "npm"
-			},
-			{
-				"command": "npm-script.test",
-				"title": "test",
-				"category": "npm"
-			}
-		],
-		"keybindings": [
-			{
-				"command": "npm-script.showOutput",
-				"key": "Ctrl+R L",
-				"mac": "Cmd+R L"
-			},
-			{
-				"command": "npm-script.run",
-				"key": "Ctrl+R Shift+R",
-				"mac": "Cmd+R Shift+R"
-			},
-			{
-				"command": "npm-script.rerun-last-script",
-				"key": "Ctrl+R R",
-				"mac": "Cmd+R R"
-			},
-			{
-				"command": "npm-script.test",
-				"key": "Ctrl+R T",
-				"mac": "Cmd+R T"
-			}
-		],
-		"configuration": {
-			"type": "object",
-			"title": "npm",
-			"properties": {
-				"npm.runInTerminal": {
-					"type": "boolean",
-					"default": true,
-					"description": "Run commands in a terminal"
-				},
-				"npm.includeDirectories": {
-					"type": "array",
-					"default": [],
-					"description": "Look for 'package.json' files in these directories"
-				},
-				"npm.useRootDirectory": {
-					"type": "boolean",
-					"default": true,
-					"description": "Look for 'package.json' in the root directory of the workspace"
-				}
-			}
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-		"lint": "tslint -c tslint.json src/*.ts",
-		"postinstall": "node ./node_modules/vscode/bin/install"
-	},
-	"devDependencies": {
-		"typescript": "^1.7.5",
-		"vscode": "^0.11.0",
-		"tslint": "3.3.0"
-	},
-	"dependencies": {
-		"run-in-terminal": "^0.0.2"
-	}
+  "name": "vscode-npm-script",
+  "description": "Run npm scripts from the Command Palette",
+  "displayName": "npm Script Runner",
+  "version": "0.0.12",
+  "publisher": "eg2",
+  "icon": "npm_icon.png",
+  "engines": {
+    "vscode": "^0.10.6"
+  },
+  "homepage": "https://github.com/Microsoft/vscode-npm-scripts/blob/master/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/vscode-npm-scripts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/vscode-npm-scripts/issues"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:npm-script.install",
+    "onCommand:npm-script.run",
+    "onCommand:npm-script.showOutput",
+    "onCommand:npm-script.rerun-last-script",
+    "onCommand:npm-script.terminate-script",
+    "onCommand:npm-script.test"
+  ],
+  "main": "./out/src/main",
+  "contributes": {
+    "commands": [
+      {
+        "command": "npm-script.install",
+        "title": "install",
+        "category": "npm"
+      },
+      {
+        "command": "npm-script.run",
+        "title": "Run script",
+        "category": "npm"
+      },
+      {
+        "command": "npm-script.showOutput",
+        "title": "Show output",
+        "category": "npm"
+      },
+      {
+        "command": "npm-script.rerun-last-script",
+        "title": "Rerun last script",
+        "category": "npm"
+      },
+      {
+        "command": "npm-script.terminate-script",
+        "title": "Terminate script",
+        "category": "npm"
+      },
+      {
+        "command": "npm-script.test",
+        "title": "test",
+        "category": "npm"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "npm-script.showOutput",
+        "key": "Ctrl+R L",
+        "mac": "Cmd+R L"
+      },
+      {
+        "command": "npm-script.run",
+        "key": "Ctrl+R Shift+R",
+        "mac": "Cmd+R Shift+R"
+      },
+      {
+        "command": "npm-script.rerun-last-script",
+        "key": "Ctrl+R R",
+        "mac": "Cmd+R R"
+      },
+      {
+        "command": "npm-script.terminate-script",
+        "key": "Ctrl+R Shift+X",
+        "mac": "Cmd+R Shift+X"
+      },
+      {
+        "command": "npm-script.test",
+        "key": "Ctrl+R T",
+        "mac": "Cmd+R T"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "npm",
+      "properties": {
+        "npm.runInTerminal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run commands in a terminal"
+        },
+        "npm.includeDirectories": {
+          "type": "array",
+          "default": [],
+          "description": "Look for 'package.json' files in these directories"
+        },
+        "npm.useRootDirectory": {
+          "type": "boolean",
+          "default": true,
+          "description": "Look for 'package.json' in the root directory of the workspace"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+    "lint": "tslint -c tslint.json src/*.ts",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "devDependencies": {
+    "typescript": "^1.7.5",
+    "vscode": "^0.11.0",
+    "tslint": "3.3.0"
+  },
+  "dependencies": {
+    "run-in-terminal": "^0.0.2",
+    "tree-kill": "^1.1.0"
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,7 +178,7 @@ function runCommandInOutputWindow(args: string[], cwd: string) {
 		runningProcesses.delete(p.pid);
 
 		if(signal == 'SIGTERM') {
-			outputChannel.appendLine('Successfuly killed process');
+			outputChannel.appendLine('Successfully killed process');
 			outputChannel.appendLine('-----------------------');
 			outputChannel.appendLine('');
 		} else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,20 +101,24 @@ function rerunLastScript(): void {
 }
 
 function terminateScript(): void {
-	let items: ProcessItem[] = [];
+	if(useTerminal()) {
+		window.showInformationMessage('Killing is only supported when the setting "runInTerminal" is "false"')
+	} else {
+		let items: ProcessItem[] = [];
 
-	runningProcesses.forEach((value) => {
-		items.push(new ProcessItem(value.cmd, `kill the process ${value.process.pid}`, value.process.pid))
-	});
+		runningProcesses.forEach((value) => {
+			items.push(new ProcessItem(value.cmd, `kill the process ${value.process.pid}`, value.process.pid))
+		});
 
-	window.showQuickPick(items).then((value) => {
-		if(value) {
-			outputChannel.appendLine('');
-			outputChannel.appendLine(`Killing process ${value.label} (pid: ${value.pid})`);
-			outputChannel.appendLine('');
-			kill(value.pid, 'SIGTERM');
-		}
-	});
+		window.showQuickPick(items).then((value) => {
+			if(value) {
+				outputChannel.appendLine('');
+				outputChannel.appendLine(`Killing process ${value.label} (pid: ${value.pid})`);
+				outputChannel.appendLine('');
+				kill(value.pid, 'SIGTERM');
+			}
+		});
+	}
 }
 
 function readScripts(): any {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,7 @@ import * as fs from 'fs';
 
 import { window, commands, workspace, OutputChannel, ExtensionContext, ViewColumn, QuickPickItem } from 'vscode';
 import { runInTerminal } from 'run-in-terminal';
-
-const kill = require('tree-kill');
+import * as kill from 'tree-kill';
 
 interface Script extends QuickPickItem {
 	scriptName: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,24 @@ import * as fs from 'fs';
 import { window, commands, workspace, OutputChannel, ExtensionContext, ViewColumn, QuickPickItem } from 'vscode';
 import { runInTerminal } from 'run-in-terminal';
 
+const kill = require('tree-kill');
+
 interface Script extends QuickPickItem {
 	scriptName: string;
 	cwd: string;
 	execute(): void;
 }
+
+interface Process {
+	process: cp.ChildProcess,
+	cmd: string
+}
+
+class ProcessItem implements QuickPickItem {
+	constructor (public label: string, public description: string, public pid: number) {}
+}
+
+const runningProcesses: Map<number, Process> = new Map();
 
 let outputChannel: OutputChannel;
 let lastScript: Script = null;
@@ -26,7 +39,8 @@ function registerCommands(context: ExtensionContext) {
 	let c3 = commands.registerCommand('npm-script.run', runNpmScript);
 	let c4 = commands.registerCommand('npm-script.showOutput', showNpmOutput);
 	let c5 = commands.registerCommand('npm-script.rerun-last-script', rerunLastScript);
-	context.subscriptions.push(c1, c2, c3, c4, c5);
+	let c6 = commands.registerCommand('npm-script.terminate-script', terminateScript);
+	context.subscriptions.push(c1, c2, c3, c4, c5, c6);
 }
 
 function runNpmInstall() {
@@ -82,6 +96,23 @@ function rerunLastScript(): void {
 	}
 }
 
+function terminateScript(): void {
+	let items: ProcessItem[] = [];
+
+	runningProcesses.forEach((value) => {
+		items.push(new ProcessItem(value.cmd, `kill the process ${value.process.pid}`, value.process.pid))
+	});
+
+	window.showQuickPick(items).then((value) => {
+		if(value) {
+			outputChannel.appendLine('');
+			outputChannel.appendLine(`Killing process ${value.label} (pid: ${value.pid})`);
+			outputChannel.appendLine('');
+			kill(value.pid, 'SIGTERM');
+		}
+	});
+}
+
 function readScripts(): any {
 	let includedDirectories = getIncludedDirectories();
 	let scripts = [];
@@ -134,12 +165,28 @@ function runNpmCommand(args: string[], cwd?: string): void {
 function runCommandInOutputWindow(args: string[], cwd: string) {
 	let cmd = 'npm ' + args.join(' ');
 	let p = cp.exec(cmd, { cwd: cwd, env: process.env });
+
+	runningProcesses.set(p.pid, { process: p, cmd: cmd })
+
 	p.stderr.on('data', (data: string) => {
 		outputChannel.append(data);
 	});
 	p.stdout.on('data', (data: string) => {
 		outputChannel.append(data);
 	});
+	p.on('exit', (code, signal) => {
+		runningProcesses.delete(p.pid);
+
+		if(signal == 'SIGTERM') {
+			outputChannel.appendLine('Successfuly killed process');
+			outputChannel.appendLine('-----------------------');
+			outputChannel.appendLine('');
+		} else {
+			outputChannel.appendLine('-----------------------');
+			outputChannel.appendLine('');
+		}
+	});
+
 	showNpmOutput();
 }
 

--- a/typings/tree-kill.ts
+++ b/typings/tree-kill.ts
@@ -1,0 +1,22 @@
+declare module '~tree-kill/index' {
+	/**
+	 * Kill all processes in the process tree, including the root process.
+	 */
+
+	interface IKill {
+		(processId: number, signal?: string, callback?: (err: any) => any): void;
+	}
+
+	const kill: IKill;
+
+	export = kill;
+}
+declare module 'tree-kill/index' {
+	import main = require('~tree-kill/index');
+	export = main;
+}
+
+declare module 'tree-kill' {
+	import main = require('~tree-kill/index');
+	export = main;
+}


### PR DESCRIPTION
Hello, with this pull request I want to resolve #12 .
Now you have a command to kill a running process with its own shortcut:
 * `cmd+r shift+x` for mac
 * `ctrl+r shift+x` for other.

I've added only one package in package.json ( `tree-kill` ) but since I've installed the package with `npm install --save tree-kill`,  npm has reformatted the whole file so there are a lot of different rows. 