### PR TITLE
Add build command and save workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The extension defines a chording keyboard shortcut for the `R` key. As a consequ
 
 ## Release Notes
 
+- 0.0.13 save workspace before running scripts, added command to run `npm run build`
 - 0.0.12 added support for `npm.useRootDirectory`
 - 0.0.11 added command to run `npm test`.
 - 0.0.7 adding an icon and changed the display name to 'npm Script Runner'.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"onCommand:npm-script.run",
 		"onCommand:npm-script.showOutput",
 		"onCommand:npm-script.rerun-last-script",
-		"onCommand:npm-script.test"
+		"onCommand:npm-script.test",
+		"onCommand:npm-script.build"
 	],
 	"main": "./out/src/main",
 	"contributes": {
@@ -52,6 +53,11 @@
 			{
 				"command": "npm-script.test",
 				"title": "test",
+				"category": "npm"
+			},
+			{
+				"command": "npm-script.build",
+				"title": "build",
 				"category": "npm"
 			}
 		],

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,8 @@ function registerCommands(context: ExtensionContext) {
 	let c3 = commands.registerCommand('npm-script.run', runNpmScript);
 	let c4 = commands.registerCommand('npm-script.showOutput', showNpmOutput);
 	let c5 = commands.registerCommand('npm-script.rerun-last-script', rerunLastScript);
-	context.subscriptions.push(c1, c2, c3, c4, c5);
+	let c6 = commands.registerCommand('npm-script.build', runNpmBuild);
+	context.subscriptions.push(c1, c2, c3, c4, c5, c6);
 }
 
 function runNpmInstall() {
@@ -38,6 +39,10 @@ function runNpmInstall() {
 
 function runNpmTest() {
 	runNpmCommand(['test']);
+}
+
+function runNpmBuild() {
+	runNpmCommand(['run-script', 'build']);
 }
 
 function showNpmOutput(): void {
@@ -120,15 +125,17 @@ function readScripts(): any {
 }
 
 function runNpmCommand(args: string[], cwd?: string): void {
-	if (!cwd) {
-		cwd = workspace.rootPath;
-	}
+	workspace.saveAll().then(() => {
+		if (!cwd) {
+			cwd = workspace.rootPath;
+		}
 
-	if (useTerminal()) {
-		runCommandInTerminal(args, cwd);
-	} else {
-		runCommandInOutputWindow(args, cwd);
-	}
+		if (useTerminal()) {
+			runCommandInTerminal(args, cwd);
+		} else {
+			runCommandInOutputWindow(args, cwd);
+		}
+	});
 }
 
 function runCommandInOutputWindow(args: string[], cwd: string) {


### PR DESCRIPTION
Firstly, save the workspace before executing npm scripts. This is more in line with the behavior of VSCode's built-in build and test commands. 

Additionally add a "build" command which executes the same npm script. This is also in line with VSCode's "test" and "build" commands and allows a Node project to skip creation of tasks.json.