### PR TITLE
Correct execution of test script.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -408,7 +408,7 @@ function runNpmUninstallInOutputWindow(...args: string[]) {
 }
 
 function runNpmTest() {
-	runNpmCommandInPackages(['run-script', 'test'], true);
+	runNpmCommandInPackages(['test'], true);
 }
 
 function runNpmStart() {


### PR DESCRIPTION
Using ['run-script', 'test'] for the call is adding an additional parameter to the call. This can cause errors like below:
```
λ npm run-script test test

> muninn@1.0.2 pretest C:\Users\bcreel\Documents\Node\muninn
> copy test\budgetsTest.sqlite test\budgets.sqlite

        1 file(s) copied.

> muninn@1.0.2 test C:\Users\bcreel\Documents\Node\muninn
> tape test/tests.js | tap-difflet "test"

Usage: tap-difflet [options]

npm ERR! Windows_NT 6.1.7601
```
This is an easy fix; 'run-script' is not required since NPM directly supports 'test' as a command.