### PR TITLE
Add npm audit command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"onCommand:npm-script.rerun-last-script",
 		"onCommand:npm-script.terminate-script",
 		"onCommand:npm-script.test",
-		"onCommand:npm-script.start"
+		"onCommand:npm-script.start",
+		"onCommand:npm-script.audit"
 	],
 	"main": "./out/src/main",
 	"contributes": {
@@ -73,6 +74,11 @@
 			{
 				"command": "npm-script.build",
 				"title": "Run Build",
+				"category": "npm"
+			},
+			{
+				"command": "npm-script.audit",
+				"title": "Run Audit",
 				"category": "npm"
 			}
 		],

--- a/src/main.ts
+++ b/src/main.ts
@@ -303,6 +303,7 @@ function registerCommands(context: ExtensionContext) {
 		commands.registerCommand('npm-script.showOutput', showNpmOutput),
 		commands.registerCommand('npm-script.rerun-last-script', rerunLastScript),
 		commands.registerCommand('npm-script.build', runNpmBuild),
+		commands.registerCommand('npm-script.audit', runNpmAudit),
 		commands.registerCommand('npm-script.installInOutputWindow', runNpmInstallInOutputWindow),
 		commands.registerCommand('npm-script.uninstallInOutputWindow', runNpmUninstallInOutputWindow),
 		commands.registerCommand('npm-script.validate', validateAllDocuments),
@@ -465,6 +466,10 @@ function runNpmStart() {
 
 function runNpmBuild() {
 	runNpmCommandInPackages(['build'], true);
+}
+
+function runNpmAudit() {
+	runNpmCommandInPackages(['audit'], true);
 }
 
 function runNpmScript(): void {


### PR DESCRIPTION
This Pull Request adds a command to run [npm audit](https://docs.npmjs.com/cli/audit), which scans your project for known security vulnerabilities.

See https://docs.npmjs.com/getting-started/running-a-security-audit for more information.

Note that this feature is only available from `npm@6`.