### PR TITLE
Add option based on config to disable touchbar from showing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Support for Macbook Pro touch bar. You can run the following commands:
 - `npm.useRootDirectory` define whether the root directory of the workspace should be ignored, the default is `false`.
 - `npm.runSilent` run npm commands with the `--silent` option, the default is `false`.
 - `npm.bin` custom npm bin name, the default is `npm`.
+- `npm.enableTouchbar` Enable the npm scripts on macOS touchbar.
 
 ##### Example
 

--- a/package.json
+++ b/package.json
@@ -103,19 +103,23 @@
 			"touchBar": [
 				{
 					"command": "npm-script.install",
-					"group": "navigation@+1"
+					"group": "navigation@+1",
+					"when": "config.npm.enableTouchbar"
 				},
 				{
 					"command": "npm-script.build",
-					"group": "navigation@+4"
+					"group": "navigation@+4",
+					"when": "config.npm.enableTouchbar"
 				},
 				{
 					"command": "npm-script.test",
-					"group": "navigation@+3"
+					"group": "navigation@+3",
+					"when": "config.npm.enableTouchbar"
 				},
 				{
 					"command": "npm-script.start",
-					"group": "navigation@+2"
+					"group": "navigation@+2",
+					"when": "config.npm.enableTouchbar"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -181,6 +181,12 @@
 					"scope": "resource",
 					"default": true,
 					"description": "Validate installed modules"
+				},
+				"npm.enableTouchbar": {
+					"type": "boolean",
+					"scope": "resource",
+					"default": false,
+					"description": "Enable the npm scripts on macOS touchbar."
 				}
 			}
 		}


### PR DESCRIPTION
I added the following option in config in order to disable touchbar from showing.

> ```json
> "touchBar": [
> 		{
> 			"command": "npm-script.install",
> 			"group": "navigation@+1",
> 			"when": "config.npm.enableTouchbar"
> 		}
> ```