### PR TITLE
Use `yarn` if a `yarn.lock` is detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node npm
+# Node npm xxx
 
 This extension supports running npm scripts defined in the `package.json` file and validating the installed modules
 against the dependencies defined in the `package.json`.


### PR DESCRIPTION
This is a test PR only.

Fixes #81