### PR TITLE
Eg/keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # vscode-npm-scripts Changelog
+- 0.3.26 [#171](https://github.com/Microsoft/vscode-npm-scripts/issues/171) Change the keybindings to not use the R as their chording character
 - 0.3.25 Address github reported vulnerabilities.
 - 0.3.24 Update the `thirdpartynotices.txt` file.
 - 0.3.23 Address github reported vulnerabilities.
@@ -11,7 +12,7 @@
 - 0.3.16 Update dependencies and fix the CVE link below.
 - 0.3.15 Fix [CVE-2021-26700](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-26700)
 - 0.3.14 Add badges to README.md
-- 0.3.13 Fix for [#129](https://github.com/Microsoft/vscode-npm-scripts/issues/#129) Add !terminalFocus to keyboard extensions that use Ctrl + R
+- 0.3.13 Fix for [#129](https://github.com/Microsoft/vscode-npm-scripts/issues/129) Add !terminalFocus to keyboard extensions that use Ctrl + R
 - 0.3.12 Address github reported vulnerabilities.
 - 0.3.11 Address github reported vulnerabilities. Migrate from tslint to eslint.
 - 0.3.10 Address github reported vulnerabilities.
@@ -19,8 +20,8 @@
 - 0.3.8 Address github reported vulnerabilities.
 - 0.3.7 Add setting `npm.enableTouchbar` to control whether npm commands should be shown in the touchbar.
 - 0.3.6 Add Macbook-Pro's touch bar support
-- 0.3.5 add support for running `npm audit` [#62](https://github.com/Microsoft/vscode-npm-scripts/issues/#62) Handle no scripts found gracefully
-- 0.3.4 fix for [#60](https://github.com/Microsoft/vscode-npm-scripts/issues/#60) Handle no scripts found gracefully
+- 0.3.5 add support for running `npm audit` [#62](https://github.com/Microsoft/vscode-npm-scripts/issues/62) Handle no scripts found gracefully
+- 0.3.4 fix for [#60](https://github.com/Microsoft/vscode-npm-scripts/issues/60) Handle no scripts found gracefully
 - 0.3.3 fix for [#46](https://github.com/Microsoft/vscode-npm-scripts/issues/46) Cannot read property 'uri' of undefined
 - 0.3.1 fix for [#44](https://github.com/Microsoft/vscode-npm-scripts/issues/44) Exception when the workspace contains a root folder with another scheme than 'file'
 - 0.3.0 support multiple root folders

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Support for Macbook Pro touch bar. You can run the following commands:
 - `npm.runSilent` run npm commands with the `--silent` option, the default is `false`.
 - `npm.bin` custom npm bin name, the default is `npm`.
 - `npm.enableTouchbar` Enable the npm scripts on macOS touchbar.
+- `npm.oldKeybindings.enable` Enable the original npm keybindings that start with `cmd/ctrl R`
 
 ### Example
 
@@ -66,7 +67,16 @@ Support for Macbook Pro touch bar. You can run the following commands:
 
 ## Keyboard Shortcuts
 
-The extension defines a chording keyboard shortcut for the `R` key. As a consequence an existing keybinding for `R` is not executed immediately. If this is not desired, then please bind another key for these commands, see the [customization](https://code.visualstudio.com/docs/customization/keybindings) documentation.
+This extension originally defined a chording keyboard shortcut for the `R` key. This has resulted in conflicts with the keybindings provided by VS Code and has caused frustration. To avoid these conflicts the keybindings have been changed to use the existing chording shortcut starting with the `K` key. The following table shows the default key bindings that can always be changed, see the [customization](https://code.visualstudio.com/docs/customization/keybindings) documentation.
+
+| Command     | Old         | New       |
+| ----------- | ----------- |-----------|
+| Rerun last script | `CMD+R R` | `CMD+K L` |
+| Select script to run | `CMD+R SHIFT+R` | `CMD+K SHIFT+R` |
+| Terminate running script | `CMD+R SHIFT+X` | `CMD+K SHIFT+X` |
+| Run test script | `CMD+R T` | `CMD+K T` |
+
+If you prefer the old keybindings starting with `R` you can define the setting `npm.oldKeybindings.enable` to `true`.
 
 [vs-url]: https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script
 [vs-image]: https://vsmarketplacebadge.apphb.com/version/eg2.vscode-npm-script.svg

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ This extension originally defined a chording keyboard shortcut for the `R` key. 
 | Command     | Old         | New       |
 | ----------- | ----------- |-----------|
 | Rerun last script | `CMD+R R` | `CMD+K L` |
-| Select script to run | `CMD+R SHIFT+R` | `CMD+K SHIFT+R` |
-| Terminate running script | `CMD+R SHIFT+X` | `CMD+K SHIFT+X` |
-| Run test script | `CMD+R T` | `CMD+K T` |
+| Select a script to run | `CMD+R SHIFT+R` | `CMD+K SHIFT+R` |
+| Terminate the running script | `CMD+R SHIFT+X` | `CMD+K SHIFT+X` |
+| Run the test script | `CMD+R T` | `CMD+K T` |
 
 If you prefer the old keybindings starting with `R` you can define the setting `npm.oldKeybindings.enable` to `true`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-npm-script",
-	"version": "0.3.24",
+	"version": "0.3.25",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-npm-script",
-			"version": "0.3.24",
+			"version": "0.3.25",
 			"dependencies": {
 				"jsonc-parser": "^2.1.0",
 				"run-in-terminal": "^0.0.2",
@@ -15,7 +15,7 @@
 			"devDependencies": {
 				"@types/mocha": "^2.2.32",
 				"@types/node": "^7.0.43",
-				"@types/vscode": "^1.44.0",
+				"@types/vscode": "^1.66.0",
 				"@typescript-eslint/eslint-plugin": "^2.18.0",
 				"@typescript-eslint/parser": "^2.18.0",
 				"eslint": "^8.0.1",
@@ -26,7 +26,7 @@
 				"webpack-cli": "^4.9.1"
 			},
 			"engines": {
-				"vscode": "^1.44.0"
+				"vscode": "^1.66.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -151,9 +151,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-			"integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -3219,9 +3219,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-			"integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -144,55 +144,55 @@
 				"command": "npm-script.showOutput",
 				"key": "Ctrl+R L",
 				"mac": "Cmd+R L",
-				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
+				"when": "!terminalFocus && config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.run",
 				"key": "Ctrl+R Shift+R",
 				"mac": "Cmd+R Shift+R",
-				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
+				"when": "!terminalFocus && config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.rerun-last-script",
 				"key": "Ctrl+R R",
 				"mac": "Cmd+R R",
-				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
+				"when": "!terminalFocus && config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.terminate-script",
 				"key": "Ctrl+R Shift+X",
 				"mac": "Cmd+R Shift+X",
-				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
+				"when": "!terminalFocus && config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.test",
 				"key": "Ctrl+R T",
 				"mac": "Cmd+R T",
-				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
+				"when": "!terminalFocus && config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.run",
-				"key": "Ctrl+K N Shift+R",
-				"mac": "Cmd+K N Shift+R",
-				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+				"key": "Ctrl+K Shift+R",
+				"mac": "Cmd+K Shift+R",
+				"when": "!config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.rerun-last-script",
-				"key": "Ctrl+K N R",
-				"mac": "Cmd+K N R",
-				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+				"key": "Ctrl+K L",
+				"mac": "Cmd+K  L",
+				"when": "!config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.terminate-script",
-				"key": "Ctrl+K N R Shift+X",
-				"mac": "Cmd+K N Shift+X",
-				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+				"key": "Ctrl+K Shift+X",
+				"mac": "Cmd+K Shift+X",
+				"when": "!config.npm.oldKeybindings.enable"
 			},
 			{
 				"command": "npm-script.test",
-				"key": "Ctrl+K N R T",
-				"mac": "Cmd+K N T",
-				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+				"key": "Ctrl+K T",
+				"mac": "Cmd+K T",
+				"when": "!config.npm.oldKeybindings.enable"
 			}
 		],
 		"configuration": {
@@ -233,7 +233,7 @@
 					"default": false,
 					"description": "Enable npm commands in the macOS touchbar."
 				},
-				"npm.keybindingCompatibility.enable": {
+				"npm.oldKeybindings.enable": {
 					"type": "boolean",
 					"scope": "resource",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -137,31 +137,55 @@
 				"command": "npm-script.showOutput",
 				"key": "Ctrl+R L",
 				"mac": "Cmd+R L",
-				"when": "!terminalFocus"
+				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
 			},
 			{
 				"command": "npm-script.run",
 				"key": "Ctrl+R Shift+R",
 				"mac": "Cmd+R Shift+R",
-				"when": "!terminalFocus"
+				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
 			},
 			{
 				"command": "npm-script.rerun-last-script",
 				"key": "Ctrl+R R",
 				"mac": "Cmd+R R",
-				"when": "!terminalFocus"
+				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
 			},
 			{
 				"command": "npm-script.terminate-script",
 				"key": "Ctrl+R Shift+X",
 				"mac": "Cmd+R Shift+X",
-				"when": "!terminalFocus"
+				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
 			},
 			{
 				"command": "npm-script.test",
 				"key": "Ctrl+R T",
 				"mac": "Cmd+R T",
-				"when": "!terminalFocus"
+				"when": "!terminalFocus && config.npm.keybindingCompatibility.enable"
+			},
+			{
+				"command": "npm-script.run",
+				"key": "Ctrl+K N Shift+R",
+				"mac": "Cmd+K N Shift+R",
+				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+			},
+			{
+				"command": "npm-script.rerun-last-script",
+				"key": "Ctrl+K N R",
+				"mac": "Cmd+K N R",
+				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+			},
+			{
+				"command": "npm-script.terminate-script",
+				"key": "Ctrl+K N R Shift+X",
+				"mac": "Cmd+K N Shift+X",
+				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
+			},
+			{
+				"command": "npm-script.test",
+				"key": "Ctrl+K N R T",
+				"mac": "Cmd+K N T",
+				"when": "!terminalFocus && !config.npm.keybindingCompatibility.enable"
 			}
 		],
 		"configuration": {
@@ -202,6 +226,12 @@
 					"scope": "resource",
 					"default": false,
 					"description": "Enable npm commands in the macOS touchbar."
+				},
+				"npm.keybindingCompatibility.enable": {
+					"type": "boolean",
+					"scope": "resource",
+					"default": true,
+					"description": "Enable the old cmd/ctrl R chording key bindings."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-npm-script",
 	"description": "npm support for VS Code",
 	"displayName": "npm",
-	"version": "0.3.25",
+	"version": "0.3.26",
 	"publisher": "eg2",
 	"icon": "npm_icon.png",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	],
 	"activationEvents": [
 		"onLanguage:json",
+		"onCommand:npm-script.showKeybindingsChangedWarning",
 		"onCommand:npm-script.install",
 		"onCommand:npm-script.run",
 		"onCommand:npm-script.showOutput",
@@ -141,6 +142,12 @@
 		},
 		"keybindings": [
 			{
+				"command": "npm-script.showKeybindingsChangedWarning",
+				"key": "Ctrl+R",
+				"mac": "Cmd+R",
+				"when": "!config.npm.keybindingsChangedWarningShown"
+			},
+			{
 				"command": "npm-script.showOutput",
 				"key": "Ctrl+R L",
 				"mac": "Cmd+R L",
@@ -238,6 +245,12 @@
 					"scope": "resource",
 					"default": true,
 					"description": "Enable the old cmd/ctrl R chording key bindings."
+				},
+				"npm.keybindingsChangedWarningShown": {
+					"type": "boolean",
+					"scope": "application",
+					"default": false,
+					"description": "Show a warning that the keybindings have changed."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
 	"devDependencies": {
 		"@types/mocha": "^2.2.32",
 		"@types/node": "^7.0.43",
-		"@types/vscode": "^1.44.0",
+		"@types/vscode": "^1.66.0",
 		"@typescript-eslint/eslint-plugin": "^2.18.0",
 		"@typescript-eslint/parser": "^2.18.0",
 		"eslint": "^8.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import {
 	window, commands, workspace, languages, OutputChannel, ExtensionContext, ViewColumn,
 	QuickPickItem, Terminal, DiagnosticCollection, Diagnostic, Range, TextDocument, DiagnosticSeverity,
-	CodeActionProvider, CodeActionContext, CancellationToken, Command, Uri
+	CodeActionProvider, CodeActionContext, CancellationToken, Command, Uri, env
 } from 'vscode';
 
 import { runInTerminal } from 'run-in-terminal';
@@ -192,6 +192,26 @@ export function activate(context: ExtensionContext) {
 	});
 
 	context.subscriptions.push(languages.registerCodeActionsProvider({ language: 'json', scheme: 'file' }, new NpmCodeActionProvider()));
+
+	showKeybindingWarning(context);
+}
+
+async function showKeybindingWarning(context: ExtensionContext) {
+	context.globalState?.setKeysForSync([
+		'keyBindingWarningShown'
+	]);
+	const gotIt = "OK, Got It";
+	const learnMore = "Learn More";
+
+	const warningShown = context.globalState.get<boolean>('keyBindingWarningShown');
+	if (!warningShown) {
+		const result = await window.showWarningMessage("The key bindings of the npm-scripts extension have changed!", learnMore, gotIt);
+		if (result === gotIt) {
+			context.globalState.update('keyBindingWarningShown', true);
+		} else if (result === learnMore) {
+			env.openExternal(Uri.parse('https://github.com/microsoft/vscode-npm-scripts#keyboard-shortcuts'));
+		}
+	}
 }
 
 export function deactivate() {


### PR DESCRIPTION
The extension has defined a chording keybinding starting with R that has conflicted with keybindings from VS Code. Please the start the review by reviewing the README that provides the context.

This Pull Request tries to fix this early mistake:
- it defines new key bindings in the command K key binding space
- it provides an option to use the old key bindings
- it shows a warning on activation that the keybindings have changed.